### PR TITLE
Use 7z for packing to preserve file permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -70,10 +70,7 @@ jobs:
     - name: Publish
       run: dotnet publish Pack3r.Console --self-contained -c Release -o release_dir -r ${{ matrix.config.rid }}
     - name: Create Zip File
-      uses: papeloto/action-zip@v1
-      with:
-        files: ./release_dir
-        dest: ./pack3r-release.zip
+      run: 7z a -r pack3r-release.zip ./release_dir
     - name: Upload release asset
       id: upload-release-asset
       uses: actions/upload-release-asset@v1


### PR DESCRIPTION
7-zip preserves file permissions while packing on Linux, so the binary is executable out of box on Linux, instead of having `644` permissions. 