### PR TITLE
fix: corrections to wav file integrity checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,3 +363,6 @@ MigrationBackup/
 FodyWeavers.xsd
 
 .release/
+
+# Rider editor config
+.idea/

--- a/Pack3r.Core/Services/IntegrityChecker.cs
+++ b/Pack3r.Core/Services/IntegrityChecker.cs
@@ -172,11 +172,13 @@ public sealed class IntegrityChecker(ILogger<IntegrityChecker> logger, AppLifeti
             if (fmt.Channels is not 1)
                 errors.Add($"expected mono instead of {fmt.Channels} channels");
 
-            if (fmt.BitsPerSample is not (8 or 16 or 32))
+            if (fmt.BitsPerSample is not (8 or 16))
                 errors.Add($"expected 8 or 16 bits per sample instead of {fmt.BitsPerSample}");
 
             if (fmt.SampleRate is not (44100 or 44100 / 2 or 44100 / 4))
-                errors.Add($"expected 44.1 kHz supported sample rate instead of {fmt.SampleRate}");
+                errors.Add(fmt.SampleRate > 44100
+                    ? $"excessively high sample rate ({fmt.SampleRate / 1000}kHz > 44.1kHz), downsampling will occur"
+                    : $"expected 44.1/22/11kHz sample rate instead of {fmt.SampleRate / 1000}kHz, resampling will occur");
 
             if (errors.Count > 0)
                 return $"invalid audio format: {string.Join(" | ", errors)}";


### PR DESCRIPTION
- 32-bit sounds are not supported.
- All sample rates are supported, the game will handle resampling to `s_khz` value.
- Higher than 44.1kHz sample rate sounds are fine, but 2.60b only supports 44.1kHz sample rate and will downsample (ETL and ETe both support 48kHz). Warn the user about an excessively high quality sound, rather than telling them that the format is not supported.