### PR TITLE
Fix false-positive missing asset errors for misc_models, skies, and shader material references

### DIFF
--- a/Pack3r.Core/Models/Resource.cs
+++ b/Pack3r.Core/Models/Resource.cs
@@ -52,6 +52,8 @@ public sealed class Resource : IEquatable<Resource>
         IResourceSource source,
         bool sourceOnly = false)
     {
+        value = value.NormalizeSlashes();
+
         if (isShader)
             value = value.TrimTextureExtension();
 
@@ -66,6 +68,7 @@ public sealed class Resource : IEquatable<Resource>
 
     private Resource(QString value, IResourceSource source)
     {
+        value = value.NormalizeSlashes();
         Global.EnsureQPathLength(value);
         Value = value.TrimTextureExtension();
         IsShader = true;

--- a/Pack3r.Core/Models/Resource.cs
+++ b/Pack3r.Core/Models/Resource.cs
@@ -55,7 +55,9 @@ public sealed class Resource : IEquatable<Resource>
         if (isShader)
             value = value.TrimTextureExtension();
 
-        Global.EnsureQPathLength(value);
+        if (!sourceOnly)
+            Global.EnsureQPathLength(value);
+
         Value = value;
         IsShader = isShader;
         Source = source;

--- a/Pack3r.Core/Models/Resource.cs
+++ b/Pack3r.Core/Models/Resource.cs
@@ -55,7 +55,7 @@ public sealed class Resource : IEquatable<Resource>
         value = value.NormalizeSlashes();
 
         if (isShader)
-            value = value.TrimTextureExtension();
+            value = value.TrimExtension();
 
         if (!sourceOnly)
             Global.EnsureQPathLength(value);
@@ -70,7 +70,7 @@ public sealed class Resource : IEquatable<Resource>
     {
         value = value.NormalizeSlashes();
         Global.EnsureQPathLength(value);
-        Value = value.TrimTextureExtension();
+        Value = value.TrimExtension();
         IsShader = true;
         Source = source;
     }

--- a/Pack3r.Core/Parsers/ShaderParser.cs
+++ b/Pack3r.Core/Parsers/ShaderParser.cs
@@ -393,14 +393,13 @@ public class ShaderParser(
                         continue;
                     }
 
-                    if (token.Span.Length == 1 && token.Span.Equals("-", StringComparison.Ordinal))
+                    // '-' farbox means no envbox is loaded, see ParseSkyParms in tr_shader.c
+                    if (!(token.Span.Length == 1 && token.Span.Equals("-", StringComparison.Ordinal)))
                     {
-                        token = shader.Name;
-                    }
-
-                    foreach (var suffix in _skySuffixes)
-                    {
-                        shader.Resources.Add($"{token}{suffix}".AsMemory());
+                        foreach (var suffix in _skySuffixes)
+                        {
+                            shader.Resources.Add($"{token}{suffix}".AsMemory());
+                        }
                     }
                 }
                 else if (line.MatchKeyword("sunshader", out token))

--- a/Pack3r.Core/QString.cs
+++ b/Pack3r.Core/QString.cs
@@ -62,6 +62,19 @@ public readonly struct QString :
 
     public bool Equals(string? other) => other.AsSpan().Equals(Span, StringComparison.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// Replaces backslashes with forward slashes, mirroring <see cref="QPath"/>'s normalization.
+    /// Needed for values parsed directly from .map/.ase files, which may contain
+    /// Windows-style paths left over from authoring/exporting on Windows.
+    /// </summary>
+    public QString NormalizeSlashes()
+    {
+        if (!Value.Span.Contains('\\'))
+            return this;
+
+        return new QString(string.Create(Value.Length, Value, (dst, src) => src.Span.Replace(dst, '\\', '/')).AsMemory().TrimStart('/'));
+    }
+
     public QString TrimTextureExtension() => Value.Span.GetTextureExtension() switch
     {
         TextureExtension.Tga or TextureExtension.Jpg => new QString(Value[..^4]),


### PR DESCRIPTION
## Summary

Fixes four related false-positive errors found while packing a real production map. Together they took a fatal parse error down to a completely clean dry run, with no change to what actually gets packed for correctly-formed references.

## Commits

**fix: skip qpath length check for source-only misc_model paths**
`misc_model` paths are baked into the BSP and never read by the engine at runtime, so the 64-char path limit shouldn't apply to them. `d01b952` tried to fix this but the length check was still running unconditionally — any misc_model path over 64 chars still hit a fatal error and aborted the whole run.

**fix: skyparms with '-' farbox should not require skybox images**
A `-` farbox in `skyparms` is standard shader syntax meaning "no envbox, don't load skybox images" (verified against the original engine source). Pack3r instead treated it as "use the shader's own name" and demanded 6 skybox images that were never supposed to exist, causing false "asset not found" errors.

**fix: normalize backslashes in resource paths from .map/.ase files**
`.map`/`.ase` files sometimes contain Windows-style backslash paths left over from authoring/export. These files genuinely existed, but the mismatched separator meant they couldn't be matched against Pack3r's forward-slash-normalized asset index. Now normalized the same way filesystem paths already are.

**fix: strip any extension from shader resource lookup keys, not just tga/jpg**
Shader references were only stripped of `.tga`/`.jpg` extensions before being looked up, but the shader registry is always keyed without any extension. A material reference with any other extension (e.g. a `.bmp` in an ASE model) would miss its matching shader entirely and get misreported as missing.